### PR TITLE
Add optional localtunnel support for server mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 
 # The following variables are enough to run the agent in local mode
 OPENAI_API_KEY=your_openai_api_key
-OPENAI_MODEL=gpt-4.1-nano-2025-04-14
+OPENAI_MODEL=your_preferred_model
 LOG_LEVEL=INFO
 LOG_FILE=agent.log
 
@@ -10,3 +10,9 @@ LOG_FILE=agent.log
 WEBHOOK_AUTH_TOKEN=your_webhook_auth_token
 AGENTARENA_API_KEY=aa-...
 DATA_DIR=./data
+
+# Optional for localtunnel
+ENABLE_LOCALTUNNEL=false
+LOCALTUNNEL_SUBDOMAIN=my-agent-audit
+LOCALTUNNEL_HOST=https://localtunnel.me
+LOCALTUNNEL_COMMAND=npx --yes localtunnel

--- a/README.md
+++ b/README.md
@@ -48,24 +48,55 @@ LOG_FILE=agent.log
 
 ### Server Mode
 
-⚠️ **Warning** ⚠️ - The platform has not been released yet. For now, you can only test the agent locally.
-
 To run the agent in server mode you need to:
-1. Go to the [AgentArena website](https://app.agentarena.staging-nethermind.xyz/) and create a builder account.  
+
+1. Go to the [AgentArena website](https://agentarena.nethermind.io/) and create a builder account.
 2. Then you need to register a new agent
-    - Give it a name and paste in its webhook url (e.g. `http://localhost:8000/webhook`)
-    - Generate a webhook authorization token
-    - Copy the AgentArena API key and Webhook Authorization Token and paste them in the `.env` file.
-      ```
-      AGENTARENA_API_KEY=aa-...
-      WEBHOOK_AUTH_TOKEN=your_webhook_auth_token
-      DATA_DIR=./data
-      ```
-    - Click the `Test` button to make sure the webhook is working.
+   - Give it a name and paste in its webhook url (e.g. `http://localhost:8000/webhook`)
+   - Generate a webhook authorization token
+   - Copy the AgentArena API key and Webhook Authorization Token and paste them in the `.env` file.
+     ```
+     AGENTARENA_API_KEY=aa-...
+     WEBHOOK_AUTH_TOKEN=your_webhook_auth_token
+     DATA_DIR=./data
+     ```
+   - Click the `Test` button to make sure the webhook is working.
 3. Then you need to run the agent in server mode
-    ```bash
-    audit-agent server
-    ```
+   ```bash
+   audit-agent server
+   ```
+
+If you want a public webhook URL from your local machine, you can enable localtunnel.
+
+Set all required server env vars in `.env`:
+
+```bash
+# Required for server mode
+AGENTARENA_API_KEY=aa-...
+WEBHOOK_AUTH_TOKEN=your_webhook_auth_token
+DATA_DIR=./data
+
+# Optional for localtunnel
+ENABLE_LOCALTUNNEL=true
+LOCALTUNNEL_SUBDOMAIN=my-agent-audit
+LOCALTUNNEL_HOST=https://localtunnel.me
+LOCALTUNNEL_COMMAND=npx --yes localtunnel
+```
+
+Then run:
+
+```bash
+audit-agent server
+```
+
+Or run directly with CLI flags (useful in a startup script):
+
+```bash
+audit-agent server --localtunnel --localtunnel-subdomain my-agent-audit
+```
+
+This requests `https://my-agent-audit.localtunnel.me/webhook` as a stable URL.
+The subdomain is best-effort and may fail if already in use.
 
 By default, the agent will run on port 8000. To use a custom port, you can use the following command:
 
@@ -93,4 +124,4 @@ audit-agent --help
 
 ## License
 
-MIT 
+MIT

--- a/agent/config.py
+++ b/agent/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     agentarena_api_key: Optional[str] = Field(None, env="AGENTARENA_API_KEY")
     webhook_auth_token: Optional[str] = Field(None, env="WEBHOOK_AUTH_TOKEN")
     data_dir: Optional[str] = Field("./data", env="DATA_DIR")
+    enable_localtunnel: bool = Field(False, env="ENABLE_LOCALTUNNEL")
+    localtunnel_subdomain: Optional[str] = Field(None, env="LOCALTUNNEL_SUBDOMAIN")
+    localtunnel_host: str = Field("https://localtunnel.me", env="LOCALTUNNEL_HOST")
+    localtunnel_command: str = Field("npx --yes localtunnel", env="LOCALTUNNEL_COMMAND")
     
     class Config:
         env_file = ".env"

--- a/agent/main.py
+++ b/agent/main.py
@@ -22,6 +22,15 @@ def main():
     # Server mode arguments
     parser.add_argument("--host", help="Host for the server (server mode)", default="0.0.0.0")
     parser.add_argument("--port", help="Port for the server (server mode)", type=int, default=8000)
+    parser.add_argument(
+        "--localtunnel",
+        action="store_true",
+        help="Expose server publicly through localtunnel (server mode)",
+    )
+    parser.add_argument(
+        "--localtunnel-subdomain",
+        help="Preferred localtunnel subdomain for a stable URL (server mode)",
+    )
     
     args = parser.parse_args()
     
@@ -39,6 +48,11 @@ def main():
             print("Error: AGENTARENA_API_KEY is required for server mode")
             print("Please set the AGENTARENA_API_KEY environment variable or add it to your .env file")
             sys.exit(1)
+
+        if args.localtunnel:
+            config.enable_localtunnel = True
+        if args.localtunnel_subdomain:
+            config.localtunnel_subdomain = args.localtunnel_subdomain
             
         start_server(host=args.host, port=args.port, config=config)
     elif args.mode == "local":

--- a/agent/server.py
+++ b/agent/server.py
@@ -3,6 +3,9 @@ Server implementation for the AI agent.
 """
 import json
 import logging
+import shlex
+import subprocess
+import threading
 from typing import Optional
 import httpx
 import tempfile
@@ -343,6 +346,69 @@ async def health_check():
     """Health check endpoint."""
     return {"status": "healthy"}
 
+
+def _start_localtunnel(port: int, config: Settings) -> Optional[subprocess.Popen]:
+    """
+    Start localtunnel process for the given port.
+
+    Returns:
+        subprocess.Popen if started successfully, otherwise None.
+    """
+    cmd = shlex.split(config.localtunnel_command)
+    cmd.extend(["--port", str(port), "--host", config.localtunnel_host])
+    if config.localtunnel_subdomain:
+        cmd.extend(["--subdomain", config.localtunnel_subdomain])
+
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except FileNotFoundError:
+        logger.error(
+            "Failed to start localtunnel: command not found (%s). "
+            "Install Node.js and localtunnel or set LOCALTUNNEL_COMMAND.",
+            config.localtunnel_command,
+        )
+        return None
+    except Exception as exc:
+        logger.error("Failed to start localtunnel: %s", str(exc), exc_info=True)
+        return None
+
+    def _stream_tunnel_logs():
+        if not process.stdout:
+            return
+        for line in process.stdout:
+            logger.info("[localtunnel] %s", line.strip())
+
+    threading.Thread(target=_stream_tunnel_logs, daemon=True).start()
+    logger.info("Started localtunnel process with command: %s", " ".join(cmd))
+    if config.localtunnel_subdomain:
+        logger.info(
+            "Requested fixed localtunnel URL: %s/%s",
+            config.localtunnel_host.rstrip("/"),
+            config.localtunnel_subdomain,
+        )
+    return process
+
+
+def _stop_localtunnel(process: Optional[subprocess.Popen]):
+    """Stop localtunnel process if it is still running."""
+    if not process:
+        return
+    if process.poll() is not None:
+        return
+
+    logger.info("Stopping localtunnel process")
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+
 def start_server(host: str, port: int, config: Settings):
     """
     Start the FastAPI server.
@@ -370,4 +436,11 @@ def start_server(host: str, port: int, config: Settings):
     
     # Start the server
     logger.info(f"Starting server on {host}:{port}")
-    uvicorn.run(app, host=host, port=port) 
+    tunnel_process = None
+    if config.enable_localtunnel:
+        tunnel_process = _start_localtunnel(port=port, config=config)
+
+    try:
+        uvicorn.run(app, host=host, port=port)
+    finally:
+        _stop_localtunnel(tunnel_process)


### PR DESCRIPTION
**Summary**  
This PR adds optional `localtunnel` integration so the local webhook server can be exposed with a public URL, including best-effort fixed subdomain support.

**Changes**  
1. Server/localtunnel integration
- Added new settings in `agent/config.py`:
  - `ENABLE_LOCALTUNNEL`
  - `LOCALTUNNEL_SUBDOMAIN`
  - `LOCALTUNNEL_HOST`
  - `LOCALTUNNEL_COMMAND`
- Added server CLI flags in `agent/main.py`:
  - `--localtunnel`
  - `--localtunnel-subdomain`
- Updated `agent/server.py` to:
  - start localtunnel when enabled
  - log localtunnel output
  - gracefully stop localtunnel on shutdown

2. Env docs
- Updated `.env.example` with localtunnel-related variables and examples.

3. README docs
- Clarified localtunnel setup for server mode via:
  - `.env` configuration
  - direct CLI flags